### PR TITLE
bug: Fix for large transfer amounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "explorer-ui",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "explorer-ui",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "GPL-3.0-or-later",
       "dependencies": {
@@ -27,6 +27,7 @@
         "@polkadapt/substrate-rpc": "file:polkadapt/dist/substrate-rpc",
         "@polkadot/api": "10.9.1",
         "@polkadot/ui-shared": "3.5.1",
+        "bignumber.js": "9.1.2",
         "buffer": "^6.0.3",
         "crypto": "npm:crypto-browserify@^3.12.0",
         "ethereum-blockies-base64": "^1.0.2",
@@ -5362,9 +5363,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
-      "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
+      "version": "20.12.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
+      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6447,6 +6448,14 @@
         "node": "*"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -6803,9 +6812,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001617",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001617.tgz",
-      "integrity": "sha512-mLyjzNI9I+Pix8zwcrpxEbGlfqOkF9kM3ptzmKNw5tizSyYwMe+nGLTqMK9cO+0E+Bh6TsBxNAaHWEM8xwSsmA==",
+      "version": "1.0.30001618",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001618.tgz",
+      "integrity": "sha512-p407+D1tIkDvsEAPS22lJxLQQaG8OTBEqo0KhzfABGk0TU4juBNDSfH0hyAp/HRyx+M8L17z/ltyhxh27FTfQg==",
       "dev": true,
       "funding": [
         {
@@ -7300,9 +7309,9 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.37.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.0.tgz",
-      "integrity": "sha512-vYq4L+T8aS5UuFg4UwDhc7YNRWVeVZwltad9C/jV3R2LgVOpS9BDr7l/WL6BN0dbV3k1XejPTHqqEzJgsa0frA==",
+      "version": "3.37.1",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.37.1.tgz",
+      "integrity": "sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==",
       "dev": true,
       "dependencies": {
         "browserslist": "^4.23.0"
@@ -7960,9 +7969,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.763",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.763.tgz",
-      "integrity": "sha512-k4J8NrtJ9QrvHLRo8Q18OncqBCB7tIUyqxRcJnlonQ0ioHKYB988GcDFF3ZePmnb8eHEopDs/wPHR/iGAFgoUQ==",
+      "version": "1.4.770",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.770.tgz",
+      "integrity": "sha512-ONwOsDiVvV07CMsyH4+dEaZ9L79HMH/ODHnDS3GkIhgNqdDHJN2C18kFb0fBj0RXpQywsPJl6k2Pqg1IY4r1ig==",
       "dev": true
     },
     "node_modules/elliptic": {
@@ -13461,9 +13470,9 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
       "dev": true
     },
     "node_modules/picomatch": {
@@ -15968,9 +15977,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.15.tgz",
-      "integrity": "sha512-K9HWH62x3/EalU1U6sjSZiylm9C8tgq2mSvshZpqc7QE69RaA2qjhkW2HlNA0tFpEbtyFz7HTqbSdN4MSwUodA==",
+      "version": "1.0.16",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
+      "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
       "dev": true,
       "funding": [
         {
@@ -15988,7 +15997,7 @@
       ],
       "dependencies": {
         "escalade": "^3.1.2",
-        "picocolors": "^1.0.0"
+        "picocolors": "^1.0.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -16748,10 +16757,59 @@
         "tslib": "^2.3.0"
       }
     },
-    "polkadapt/dist/coingecko": {},
-    "polkadapt/dist/core": {},
-    "polkadapt/dist/polkascan-explorer": {},
-    "polkadapt/dist/subsquid": {},
-    "polkadapt/dist/substrate-rpc": {}
+    "polkadapt/dist/coingecko": {
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@polkadapt/core": "2.0.0"
+      }
+    },
+    "polkadapt/dist/core": {
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "rxjs": "~7.8.1"
+      }
+    },
+    "polkadapt/dist/polkascan-explorer": {
+      "version": "2.0.1",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@polkadapt/core": "2.0.0",
+        "rxjs": "~7.8.1"
+      }
+    },
+    "polkadapt/dist/subsquid": {
+      "version": "1.0.3",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@polkadapt/core": "2.0.0",
+        "rxjs": "~7.8.1"
+      }
+    },
+    "polkadapt/dist/substrate-rpc": {
+      "version": "2.0.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@polkadapt/core": "2.0.0",
+        "@polkadot/api": "*",
+        "rxjs": "~7.8.1"
+      }
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-ui",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "GPL-3.0-or-later",
   "scripts": {
     "postinstall": "npm update",
@@ -30,6 +30,7 @@
     "@polkadapt/substrate-rpc": "file:polkadapt/dist/substrate-rpc",
     "@polkadot/api": "10.9.1",
     "@polkadot/ui-shared": "3.5.1",
+    "bignumber.js": "9.1.2",
     "buffer": "^6.0.3",
     "crypto": "npm:crypto-browserify@^3.12.0",
     "ethereum-blockies-base64": "^1.0.2",

--- a/src/app/pages/network/explorer/event/event-detail/event-detail.component.ts
+++ b/src/app/pages/network/explorer/event/event-detail/event-detail.component.ts
@@ -73,15 +73,15 @@ export class EventDetailComponent implements OnInit, OnDestroy {
           filter((event) => !Array.isArray(event.attributes)), //* if attributes is an array, it's a rpc response and we can discard it
           map((event) => {
             if (event) {
+              let eventFormatted = { ...event };
               const { attributes } = event;
               if (attributes) {
                 const jsonAttributes = JSON.parse(attributes.toString());
                 const sortedKeys = Object.keys(jsonAttributes).sort();
-                // @ts-ignore
-                event.attributes = sortedKeys.map(key => jsonAttributes[key]);
+                eventFormatted.attributes = sortedKeys.map(key => jsonAttributes[key]);
               }
               this.fetchEventStatus.next(null);
-              return event;
+              return eventFormatted;
             }
             throw new Error('Event not found.')
           })

--- a/src/common/attributes/attributes/attribute-balance.component.ts
+++ b/src/common/attributes/attributes/attribute-balance.component.ts
@@ -17,6 +17,7 @@
  */
 
 import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges, ViewEncapsulation } from '@angular/core';
+import BigNumber from "bignumber.js";
 
 @Component({
   selector: 'attribute-balance',
@@ -33,7 +34,7 @@ export class AttributeBalanceComponent implements OnChanges {
   @Input() tokenDecimals: number;
   @Input() tokenSymbol: string;
 
-  convertedValue: number | null;
+  convertedValue: BigNumber | null;
   private decimals: number;
 
   constructor() {
@@ -45,10 +46,10 @@ export class AttributeBalanceComponent implements OnChanges {
     }
 
     if (changes['tokenDecimals'] || changes['attribute'] || changes['decimals']) {
-      let converted: number | null;
+      let converted: BigNumber | null;
 
       try {
-        converted = Math.max(0, parseInt(this.attribute.value as string, 10)) / Math.pow(10, this.decimals);
+        converted = BigNumber.maximum(0, (new BigNumber(this.attribute.value))).dividedBy(new BigNumber(Math.pow(10, this.decimals)));
       } catch (e) {
         converted = null;
       }


### PR DESCRIPTION
Fix large transfer amounts showing up incorrectly.

Large transfer amounts were returned in exponential notation:
<img width="1357" alt="Screen Shot 2024-05-15 at 4 37 01 PM" src="https://github.com/HorizenLabs/zkverify-explorer-ui/assets/20520369/e87869cb-8e9e-4274-a793-66aebc4fdd6a">
Added the `BigNumber.js` library to calculate the transfer amount.

Old: https://testnet-explorer.zkverify.io/v0/event/9761-4
New:
<img width="992" alt="Screen Shot 2024-05-15 at 4 34 49 PM" src="https://github.com/HorizenLabs/zkverify-explorer-ui/assets/20520369/86ccbade-511e-443e-a825-6c7de6fa5f8b">
